### PR TITLE
- Updating surefire plugin version due to Netbeans compatibility issue

### DIFF
--- a/weasis-parent/pom.xml
+++ b/weasis-parent/pom.xml
@@ -144,7 +144,9 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>2.19</version>
+                                        <!-- Updating surefire plugin version from 2.19 to 2.19.1 due to Netbeans compatibility issue. 
+                                        More information: https://netbeans.org/bugzilla/show_bug.cgi?id=256211 -->
+                                        <version>2.19.1</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Surefire 2.19 introduced an incompatibility Issue for running single test classes and/or methods with Nebeans 8.01. Version 2.19.1 fixes this issue.

More information: https://netbeans.org/bugzilla/show_bug.cgi?id=256211