### PR TITLE
Weasis codec dcm4che14 support

### DIFF
--- a/weasis-codec/weasis-image-jni/pom.xml
+++ b/weasis-codec/weasis-image-jni/pom.xml
@@ -17,6 +17,15 @@
 	</properties>
 	<build>
 		<plugins>
+    	<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.5.1</version>
+				<configuration>
+					<source>1.7</source>
+					<target>1.7</target>
+				</configuration>
+			</plugin>
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>

--- a/weasis-codec/weasis-image-jni/src/main/java/org/weasis/image/jni/NativeImageReader.java
+++ b/weasis-codec/weasis-image-jni/src/main/java/org/weasis/image/jni/NativeImageReader.java
@@ -71,8 +71,11 @@ public abstract class NativeImageReader extends ImageReader {
      * Creates a <code>ImageTypeSpecifier</code> from the <code>ImageParameters</code>. The default sample model is
      * pixel interleaved and the default color model is CS_GRAY or CS_sRGB and IndexColorModel with palettes.
      */
-    protected static final ImageTypeSpecifier createImageType(ImageParameters params, ColorSpace colorSpace,
-        byte[] redPalette, byte[] greenPalette, byte[] bluePalette, byte[] alphaPalette) throws IOException {
+    protected static final ImageTypeSpecifier createImageType(ImageParameters params, ColorSpace colorSpace, byte[] redPalette, byte[] greenPalette, byte[] bluePalette, byte[] alphaPalette) throws IOException {
+        return createImageType(params, createColorModel(params, null, null, null, null, null));
+    }
+
+    protected static final ImageTypeSpecifier createImageType(ImageParameters params, ColorModel colorModel) throws IOException {
 
         int nType = params.getDataType();
         int nWidth = params.getWidth();
@@ -97,6 +100,13 @@ public abstract class NativeImageReader extends ImageReader {
             }
             sampleModel = new PixelInterleavedSampleModel(nType, nWidth, nHeight, nBands, nScanlineStride, bandOffsets);
         }
+        return new ImageTypeSpecifier(colorModel, sampleModel);
+    }
+
+    private static ColorModel createColorModel(ImageParameters params, ColorSpace colorSpace, byte[] redPalette, byte[] greenPalette, byte[] bluePalette, byte[] alphaPalette) {
+        int nType = params.getDataType();
+        int nBands = params.getSamplesPerPixel();
+        int nBitDepth = params.getBitsPerSample();
 
         ColorModel colorModel;
         if (nBands == 1 && redPalette != null && greenPalette != null && bluePalette != null
@@ -145,8 +155,7 @@ public abstract class NativeImageReader extends ImageReader {
             colorModel = new ComponentColorModel(cs, bits, hasAlpha, false,
                 hasAlpha ? Transparency.TRANSLUCENT : Transparency.OPAQUE, nType);
         }
-
-        return new ImageTypeSpecifier(colorModel, sampleModel);
+        return colorModel;
     }
 
 
@@ -511,14 +520,21 @@ public abstract class NativeImageReader extends ImageReader {
             return null;
         }
 
-        ImageTypeSpecifier type = createImageType(img.getImageParameters(), null, null, null, null, null);
-        // Create a new raster and copy the data.
+        ColorModel cm = createColorModel(img.getImageParameters(), null, null, null, null, null);
+        ImageTypeSpecifier type = createImageType(img.getImageParameters(), cm);
         SampleModel sm = type.getSampleModel();
+        if(param != null) {
+            if (param.getDestination() != null && param.getDestination().getColorModel() != null) {
+                cm = param.getDestination().getColorModel();
+                sm = cm.createCompatibleSampleModel(img.getImageParameters().getWidth(), img.getImageParameters().getHeight());
+            }
+        }
+        // Create a new raster and copy the data.
         WritableRaster raster = Raster.createWritableRaster(sm, db, param.getDestinationOffset());
 
         long stop = System.currentTimeMillis();
         LOGGER.debug("Building BufferedImage time: {} ms", stop - start); //$NON-NLS-1$
-        return new BufferedImage(type.getColorModel(), raster, false, null);
+        return new BufferedImage(cm, raster, false, null);
     }
 
     @Override

--- a/weasis-codec/weasis-image-jni/src/main/java/org/weasis/image/jni/NativeImageReader.java
+++ b/weasis-codec/weasis-image-jni/src/main/java/org/weasis/image/jni/NativeImageReader.java
@@ -72,7 +72,7 @@ public abstract class NativeImageReader extends ImageReader {
      * pixel interleaved and the default color model is CS_GRAY or CS_sRGB and IndexColorModel with palettes.
      */
     protected static final ImageTypeSpecifier createImageType(ImageParameters params, ColorSpace colorSpace, byte[] redPalette, byte[] greenPalette, byte[] bluePalette, byte[] alphaPalette) throws IOException {
-        return createImageType(params, createColorModel(params, null, null, null, null, null));
+        return createImageType(params, createColorModel(params, colorSpace, redPalette, greenPalette, bluePalette, alphaPalette));
     }
 
     protected static final ImageTypeSpecifier createImageType(ImageParameters params, ColorModel colorModel) throws IOException {

--- a/weasis-codec/weasis-image-jni/src/main/java/org/weasis/image/jni/StreamSegment.java
+++ b/weasis-codec/weasis-image-jni/src/main/java/org/weasis/image/jni/StreamSegment.java
@@ -14,7 +14,9 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Arrays;
 
 import javax.imageio.stream.FileCacheImageInputStream;
@@ -42,7 +44,7 @@ public abstract class StreamSegment {
         if (mlImage == null) {
             return;
         }
-        // Not a good practice (should be instanceof) but necessary to remove the dependency with dcm4che lib
+        // Not a good practice (should be instanceof) but necessary to remove the dependency with dcm4che3 lib
         if ("org.dcm4che3.imageio.stream.SegmentedInputImageStream".equals(iis.getClass().getName())) {
             try {
                 Class<? extends ImageInputStream> clazz = iis.getClass();
@@ -93,35 +95,72 @@ public abstract class StreamSegment {
                         new long[] { 0 }, new int[] { (int) raf.length() }));
             }
         } else if (iis instanceof SegmentedImageInputStream) {
-            throw new IllegalArgumentException("No adaptor implemented yet for SegmentedImageInputStream");
-            // try {
-            // Field f_stream = SegmentedImageInputStream.class.getDeclaredField("stream");
-            // Field f_mapper = SegmentedImageInputStream.class.getDeclaredField("mapper");
-            // if (f_mapper != null && f_stream != null) {
-            // f_mapper.setAccessible(true);
-            // f_stream.setAccessible(true);
-            // FileImageInputStream fstream = (FileImageInputStream) f_stream.get(iis);
-            // Field f_raf = FileImageInputStream.class.getDeclaredField("raf");
-            // if (f_raf != null) {
-            // f_raf.setAccessible(true);
-            // ItemParser mapper = (ItemParser) f_mapper.get(iis);
-            // Field f_parser = ItemParser.class.getDeclaredField("firstItemOfFrame");
-            // if (f_parser != null) {
-            // f_parser.setAccessible(true);
-            // ArrayList<ItemParser.Item> items = (ArrayList<ItemParser.Item>) f_parser.get(mapper);
-            // Item item = items.get(0);
-            //
-            // RandomAccessFile raf = (RandomAccessFile) f_raf.get(fstream);
-            // segment =
-            // new FileStreamSegment(FileStreamSegment.getFileIDfromFileDescriptor(raf.getFD()),
-            // item.startPos, item.length, item.offset);
-            // }
-            // }
-            // }
-            // } catch (Exception e) {
-            // // TODO Auto-generated catch block
-            // e.printStackTrace();
-            // }
+            try {
+                Field f_stream = SegmentedImageInputStream.class.getDeclaredField("stream");
+                Field f_mapper = SegmentedImageInputStream.class.getDeclaredField("mapper");
+                if (f_mapper != null && f_stream != null) {
+                    f_mapper.setAccessible(true);
+                    f_stream.setAccessible(true);
+                    Object mapperObject = f_mapper.get(iis);
+                    // Not a good practice (should be instanceof) but necessary to remove the dependency with dcm4che14 lib
+                    if ("org.dcm4cheri.image.ItemParser".equals(mapperObject.getClass().getName())) {
+                        FileImageInputStream fstream = (FileImageInputStream) f_stream.get(iis);
+                        Field f_raf = FileImageInputStream.class.getDeclaredField("raf");
+                        if (f_raf != null) {
+                            f_raf.setAccessible(true);
+
+                            Field f_items = mapperObject.getClass().getDeclaredField("items");
+                            Method m_numberOfDataFragments = mapperObject.getClass().getMethod("getNumberOfDataFragments");
+                            //Needs to be called so that all segments are added to List "items"
+                            int nbrOfDataFragments = (int) m_numberOfDataFragments.invoke(mapperObject, new Object[]{});
+                            if (f_items != null) {
+                                f_items.setAccessible(true);
+                                ArrayList items = (ArrayList) f_items.get(mapperObject);
+                                if (items.size() > 0) {
+                                    Field f_startPos = items.get(0).getClass().getDeclaredField("startPos");
+                                    Field f_length = items.get(0).getClass().getDeclaredField("length");
+                                    Field f_offset = items.get(0).getClass().getDeclaredField("offset");
+                                    if (f_startPos != null && f_length != null) {
+                                        f_startPos.setAccessible(true);
+                                        f_length.setAccessible(true);
+                                        long[] segmentStartPositions = new long[items.size()];
+                                        int[] segmentLengths = new int[items.size()];
+                                        int startIndex = -1;
+                                        for (int i = 0; i < items.size(); i++) {
+
+                                            if(startIndex == -1 && (long) f_offset.get(items.get(i)) == iis.getStreamPosition()) {
+                                                startIndex = i;
+                                            }
+                                            segmentStartPositions[i] = (long) f_startPos.get(items.get(i));
+                                            segmentLengths[i] = (int) f_length.get(items.get(i));
+                                        }
+                                        if(startIndex != -1) {
+                                            segmentStartPositions = Arrays.copyOfRange(segmentStartPositions, startIndex, segmentStartPositions.length);
+                                            segmentLengths = Arrays.copyOfRange(segmentLengths, startIndex, segmentLengths.length);
+                                            RandomAccessFile raf = (RandomAccessFile) f_raf.get(fstream);
+                                            /*
+                                             * PS 3.5.8.2 Though a fragment may not contain encoded data from more than one frame,
+                                             * the encoded data from one frame may span multiple fragments. See note in Section 8.2.
+                                             */
+                                            FileStreamSegment segment = new FileStreamSegment(raf, FileStreamSegment.getFileIDfromFileDescriptor(raf.getFD()), segmentStartPositions, segmentLengths);
+                                            mlImage.setStreamSegment(segment);
+                                            return;
+                                        }
+                                    }
+                                }
+                            }
+
+                        }
+                    }
+                }
+                throw new IllegalArgumentException("No adaptor implemented for this type of SegmentedImageInputStream");
+            } catch (Exception e) {
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.error("getFileDescriptor from SegmentedInputImageStream", e);
+                } else {
+                    LOGGER.error(e.getMessage());
+                }
+            }
         } else if (iis instanceof FileCacheImageInputStream) {
             throw new IllegalArgumentException("No adaptor implemented yet for FileCacheImageInputStream");
         } else if (iis instanceof MemoryCacheImageInputStream) {

--- a/weasis-codec/weasis-jpeg/weasis-jpeg-codec/src/main/java/org/weasis/jpeg/NativeJPEGImageWriter.java
+++ b/weasis-codec/weasis-jpeg/weasis-jpeg-codec/src/main/java/org/weasis/jpeg/NativeJPEGImageWriter.java
@@ -98,7 +98,8 @@ final class NativeJPEGImageWriter extends NativeImageWriter {
  * This differs from the core JPEG ImageWriteParam in that:
  *
  * <ul>
- * <li>compression types are: "JPEG" (standard), "JPEG-LOSSLESS" (lossless JPEG from 10918-1/ITU-T81)</li>
+ * <li>compression types are: "JPEG" (standard), "JPEG-LOSSLESS"
+ * (lossless JPEG from 10918-1/ITU-T81), "JPEG-LS" (ISO 14495-1 lossless).</li>
  * <li>compression modes are: MODE_DEFAULT and MODE_EXPLICIT and the other modes (MODE_DISABLED and
  * MODE_COPY_FROM_METADATA) cause an UnsupportedOperationException.</li>
  * <li>isCompressionLossless() will return true if type is NOT "JPEG".</li>
@@ -109,6 +110,7 @@ final class CLibJPEGImageWriteParam extends ImageWriteParam {
 
     static final String LOSSY_COMPRESSION_TYPE = "JPEG";
     static final String LOSSLESS_COMPRESSION_TYPE = "JPEG-LOSSLESS";
+    static final String LS_COMPRESSION_TYPE = "JPEG-LS";
 
     private static final String[] compressionQualityDescriptions =
         new String[] { "Minimum useful", "Visually lossless", "Maximum useful" };
@@ -120,7 +122,7 @@ final class CLibJPEGImageWriteParam extends ImageWriteParam {
         compressionMode = MODE_EXPLICIT;
         compressionQuality = DEFAULT_COMPRESSION_QUALITY;
         compressionType = LOSSY_COMPRESSION_TYPE;
-        compressionTypes = new String[] { LOSSY_COMPRESSION_TYPE, LOSSLESS_COMPRESSION_TYPE };
+        compressionTypes = new String[] { LOSSY_COMPRESSION_TYPE, LOSSLESS_COMPRESSION_TYPE, LS_COMPRESSION_TYPE };
     }
 
     @Override

--- a/weasis-codec/weasis-jpeg/weasis-jpeg-codec/src/main/java/org/weasis/jpeg/internal/CharlsCodec.java
+++ b/weasis-codec/weasis-jpeg/weasis-jpeg-codec/src/main/java/org/weasis/jpeg/internal/CharlsCodec.java
@@ -169,8 +169,9 @@ public class CharlsCodec implements NativeCodec {
                     try (ByteStreamInfo input = libijg.FromByteArray(buffer, size)) {
 
                         // Build outputStream here and transform to an array
+                        int bytesPerSample = params.getBitsPerSample() / 8;
                         outBuf = ByteBuffer.allocateDirect(params.getWidth() * params.getHeight()
-                            * params.getSamplesPerPixel() * params.getBitsPerSample() / 16);
+                            * params.getSamplesPerPixel() * bytesPerSample);
                         outBuf.order(params.isBigEndian() ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
                         size2.put(outBuf.limit());
                         try (ByteStreamInfo outStream = libijg.FromByteArray(outBuf, size2)) {

--- a/weasis-codec/weasis-jpeg/weasis-jpeg-codec/src/main/java/org/weasis/jpeg/internal/DecoderIJG.java
+++ b/weasis-codec/weasis-jpeg/weasis-jpeg-codec/src/main/java/org/weasis/jpeg/internal/DecoderIJG.java
@@ -32,7 +32,6 @@ public interface DecoderIJG extends AutoCloseable {
 
     void deallocate();
     
-    @Override
-    default void close() {}
+    public void close();
 
 }

--- a/weasis-codec/weasis-jpeg/weasis-jpeg-codec/src/main/resources/META-INF/services/javax.imageio.spi.ImageReaderSpi
+++ b/weasis-codec/weasis-jpeg/weasis-jpeg-codec/src/main/resources/META-INF/services/javax.imageio.spi.ImageReaderSpi
@@ -1,0 +1,2 @@
+org.weasis.jpeg.NativeJLSImageReaderSpi
+org.weasis.jpeg.NativeJPEGImageReaderSpi

--- a/weasis-codec/weasis-jpeg/weasis-jpeg-codec/src/main/resources/META-INF/services/javax.imageio.spi.ImageWriterSpi
+++ b/weasis-codec/weasis-jpeg/weasis-jpeg-codec/src/main/resources/META-INF/services/javax.imageio.spi.ImageWriterSpi
@@ -1,0 +1,2 @@
+org.weasis.jpeg.NativeJLSImageWriterSpi
+org.weasis.jpeg.NativeJPEGImageWriterSpi

--- a/weasis-codec/weasis-jpeg/weasis-jpeg-parent/pom.xml
+++ b/weasis-codec/weasis-jpeg/weasis-jpeg-parent/pom.xml
@@ -12,4 +12,18 @@
 	<artifactId>weasis-jpeg-parent</artifactId>
 	<name>Parent of Native JPEG Library</name>
 	<packaging>pom</packaging>
+  <build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.5.1</version>
+				<configuration>
+					<source>1.7</source>
+					<target>1.7</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>

--- a/weasis-codec/weasis-openjpeg/weasis-openjpeg-codec/src/main/resources/META-INF/services/javax.imageio.spi.ImageReaderSpi
+++ b/weasis-codec/weasis-openjpeg/weasis-openjpeg-codec/src/main/resources/META-INF/services/javax.imageio.spi.ImageReaderSpi
@@ -1,0 +1,1 @@
+org.weasis.openjpeg.NativeJ2kImageReaderSpi

--- a/weasis-codec/weasis-openjpeg/weasis-openjpeg-codec/src/main/resources/META-INF/services/javax.imageio.spi.ImageWriterSpi
+++ b/weasis-codec/weasis-openjpeg/weasis-openjpeg-codec/src/main/resources/META-INF/services/javax.imageio.spi.ImageWriterSpi
@@ -1,0 +1,1 @@
+org.weasis.openjpeg.NativeJ2kImageWriterSpi

--- a/weasis-codec/weasis-openjpeg/weasis-openjpeg-parent/pom.xml
+++ b/weasis-codec/weasis-openjpeg/weasis-openjpeg-parent/pom.xml
@@ -12,4 +12,17 @@
 	<artifactId>weasis-openjpeg-parent</artifactId>
 	<name>Parent of OpenJPEG Library</name>
 	<packaging>pom</packaging>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.5.1</version>
+				<configuration>
+					<source>1.7</source>
+					<target>1.7</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>


### PR DESCRIPTION
Changes to get weasis-codec working with dcm4che14/dcm4chee 2.18.3 on windows 64bit
 - Java 7
 - StreamAdaptor for SegmentedImageInputStream with mapper of type org.dcm4cheri.image.ItemParser
 - ColorModel of ImageReadParam.getDestination to apply WL/WW to WADO
 - fix error with wrong Buffersize for JPEG-LS

This enables usage outside of weasis and - as far as I can see - there is no impact on rest of weasis codebase. Would be nice to see this upstream. Looking forward to hear your comments on this!