### PR TITLE
Fix plan initialisation and isodose rendering

### DIFF
--- a/weasis-dicom/weasis-dicom-rt/src/main/java/org/weasis/dicom/rt/Dose.java
+++ b/weasis-dicom/weasis-dicom-rt/src/main/java/org/weasis/dicom/rt/Dose.java
@@ -283,7 +283,7 @@ public class Dose extends HashMap<Integer, Dvh> {
         // Convert from threshold in cCy to raw pixel value threshold
         double rawThreshold = (isoDoseThreshold / 100) / this.doseGridScaling;
 
-        DicomImageElement dosePlane = (DicomImageElement) this. getDosePlaneBySlice(slicePosition);
+        DicomImageElement dosePlane = (DicomImageElement) this.getDosePlaneBySlice(slicePosition);
 
         int rows = dosePlane.getImage().toMat().rows();
         int cols = dosePlane.getImage().toMat().cols();

--- a/weasis-dicom/weasis-dicom-rt/src/main/java/org/weasis/dicom/rt/IsoDose.java
+++ b/weasis-dicom/weasis-dicom-rt/src/main/java/org/weasis/dicom/rt/IsoDose.java
@@ -24,7 +24,7 @@ public class IsoDose {
     private double thickness;
 
     private Color color;
-    private Map<Double, List<Contour>> planes;
+    private Map<String, List<Contour>> planes;
 
     public IsoDose(int level, Color color, String name, double planDose) {
         this.level = level;
@@ -69,11 +69,11 @@ public class IsoDose {
         this.thickness = value;
     }
 
-    public Map<Double, List<Contour>> getPlanes() {
+    public Map<String, List<Contour>> getPlanes() {
         return this.planes;
     }
 
-    public void setPlanes(Map<Double, List<Contour>> contours) {
+    public void setPlanes(Map<String, List<Contour>> contours) {
         this.planes = contours;
     }
 

--- a/weasis-dicom/weasis-dicom-rt/src/main/java/org/weasis/dicom/rt/Plan.java
+++ b/weasis-dicom/weasis-dicom-rt/src/main/java/org/weasis/dicom/rt/Plan.java
@@ -105,9 +105,27 @@ public class Plan implements Serializable {
         return null;
     }
 
+    public void appendName(String text) {
+        if (this.name != null && !this.name.isEmpty()) {
+            this.name += " (" + text + ")";
+        }
+        else if (this.label != null && !this.label.isEmpty()) {
+            this.name = this.label +  " (" + text + ")";
+        }
+    }
+
     @Override
     public String toString() {
-        return this.label;
+        String result = "";
+        
+        if (this.name != null && !this.name.isEmpty()) {
+            result = this.name;
+        }
+        else if (this.label != null && !this.label.isEmpty()) {
+            result = this.label;
+        }
+
+        return result;
     }
 
     @Override

--- a/weasis-dicom/weasis-dicom-rt/src/main/java/org/weasis/dicom/rt/RtDisplayTool.java
+++ b/weasis-dicom/weasis-dicom-rt/src/main/java/org/weasis/dicom/rt/RtDisplayTool.java
@@ -237,16 +237,16 @@ public class RtDisplayTool extends PluginTool implements SeriesViewerListener {
     }
 
     public JSliderW createTransparencySlider(int labelDivision, boolean displayValueInTitle) {
-        final JPanel palenSlider1 = new JPanel();
-        palenSlider1.setLayout(new BoxLayout(palenSlider1, BoxLayout.Y_AXIS));
-        palenSlider1.setBorder(new TitledBorder("Graphic Opacity"));
+        final JPanel panelSlider1 = new JPanel();
+        panelSlider1.setLayout(new BoxLayout(panelSlider1, BoxLayout.Y_AXIS));
+        panelSlider1.setBorder(new TitledBorder("Graphic Opacity"));
         DefaultBoundedRangeModel model = new DefaultBoundedRangeModel(50, 0, 0, 100);
         JSliderW s = new JSliderW(model);
         s.setLabelDivision(labelDivision);
         s.setdisplayValueInTitle(displayValueInTitle);
         s.setPaintTicks(true);
         s.setShowLabels(labelDivision > 0);
-        palenSlider1.add(s);
+        panelSlider1.add(s);
         if (s.isShowLabels()) {
             s.setPaintLabels(true);
             SliderChangeListener.setSliderLabelValues(s, model.getMinimum(), model.getMaximum(), 0.0, 100.0);
@@ -358,7 +358,7 @@ public class RtDisplayTool extends PluginTool implements SeriesViewerListener {
             ImageElement dicom = v.getImage();
             if (dicom instanceof DicomImageElement) {
                 GeometryOfSlice geometry = ((DicomImageElement) dicom).getDispSliceGeometry();
-                double z = geometry.getTLHC().getZ();
+                String keyZ = String.format("%.2f", geometry.getTLHC().getZ());
 
                 // List of detected contours from RtSet
                 List<Contour> contours =
@@ -392,7 +392,7 @@ public class RtDisplayTool extends PluginTool implements SeriesViewerListener {
                             if (containsIsoDose(listIsoDose, isoDose)) {
 
                                 // Contours for specific slice
-                                List<Contour> isoContours = isoDose.getPlanes().get(z);
+                                List<Contour> isoContours = isoDose.getPlanes().get(keyZ);
                                 if (isoContours != null) {
 
                                     // Iso dose graphics
@@ -716,8 +716,31 @@ public class RtDisplayTool extends PluginTool implements SeriesViewerListener {
 
         public String getToolTipText() {
             StructureLayer layer = (StructureLayer) getUserObject();
+            
             // TODO
-            return null;
+            double volume = layer.getStructure().getVolume();
+            String source = layer.getStructure().getVolumeSource().toString();
+
+            StringBuilder structTooltip = new StringBuilder();
+            structTooltip.append("Structure Information:");
+            structTooltip.append(String.format(source + " Volume: %.4f cm^3", volume));
+
+            //TODO: I actually need to find DVH for structure from the plan dose ...
+//            Dvh structureDvh = dose.get(structure.getRoiNumber());
+//
+//            String relativeMinDose = String.format(structureDvh.getDvhSource().toString()
+//                    + " Min Dose: %.3f %%",
+//                RtSet.calculateRelativeDose(structureDvh.getDvhMinimumDoseCGy(), plan.getRxDose()));
+//            String relativeMaxDose = String.format(
+//                    "Structure: " + structure.getRoiName() + ", " + structureDvh.getDvhSource().toString()
+//                            + " Max Dose: %.3f %%",
+//                    RtSet.calculateRelativeDose(structureDvh.getDvhMaximumDoseCGy(), plan.getRxDose()));
+//            String relativeMeanDose = String.format(
+//                    "Structure: " + structure.getRoiName() + ", " + structureDvh.getDvhSource().toString()
+//                            + " Mean Dose: %.3f %%",
+//                    RtSet.calculateRelativeDose(structureDvh.getDvhMeanDoseCGy(), plan.getRxDose()));
+
+            return structTooltip.toString();
         }
 
         @Override

--- a/weasis-dicom/weasis-dicom-rt/src/main/java/org/weasis/dicom/rt/Structure.java
+++ b/weasis-dicom/weasis-dicom-rt/src/main/java/org/weasis/dicom/rt/Structure.java
@@ -33,7 +33,7 @@ public class Structure {
     private DataSource volumeSource;
 
     private Color color;
-    private Map<Double, List<Contour>> planes;
+    private Map<String, List<Contour>> planes;
 
     public Structure() {
         this.volume = -1.0;
@@ -114,11 +114,11 @@ public class Structure {
         this.color = color;
     }
 
-    public Map<Double, List<Contour>> getPlanes() {
+    public Map<String, List<Contour>> getPlanes() {
         return this.planes;
     }
 
-    public void setPlanes(Map<Double, List<Contour>> contours) {
+    public void setPlanes(Map<String, List<Contour>> contours) {
         this.planes = contours;
     }
 


### PR DESCRIPTION
When multiple dose references are in plan consider the one delivering the highest dose to be the planned dose for treatment. Planes in IsoDose are looked up according String key that is a String representation of mm distance (fixes the issue of not rendering iso contours for testing plan).