### PR TITLE
Fix isodose rendering

### DIFF
--- a/weasis-dicom/weasis-dicom-rt/src/main/java/org/weasis/dicom/rt/Dose.java
+++ b/weasis-dicom/weasis-dicom-rt/src/main/java/org/weasis/dicom/rt/Dose.java
@@ -53,6 +53,7 @@ public class Dose extends HashMap<Integer, Dvh> {
 
     private List<MediaElement> images = new ArrayList<>();
     private Map<Integer, IsoDoseLayer> isoDoseSet = new LinkedHashMap<>();
+    private Map<String, ArrayList<Contour>> isoContourMap = new HashMap<>();
 
     // Dose LUTs
     private Pair<double[], double[]> doseMmLUT;
@@ -164,6 +165,14 @@ public class Dose extends HashMap<Integer, Dvh> {
 
     public void setIsoDoseSet(Map<Integer, IsoDoseLayer> isoDoseSet) {
         this.isoDoseSet = isoDoseSet;
+    }
+
+    public Map<String, ArrayList<Contour>> getIsoContourMap() {
+        return this.isoContourMap;
+    }
+
+    public void setIsoContourMap(Map<String, ArrayList<Contour>> isoContourMap) {
+        this.isoContourMap = isoContourMap;
     }
 
     public Pair<double[], double[]> getDoseMmLUT() {

--- a/weasis-dicom/weasis-dicom-rt/src/main/java/org/weasis/dicom/rt/Dvh.java
+++ b/weasis-dicom/weasis-dicom-rt/src/main/java/org/weasis/dicom/rt/Dvh.java
@@ -30,6 +30,7 @@ public class Dvh {
     private double[] dvhData;
     private double[] otherDvhData;
     private DataSource dvhSource;
+    private Plan plan;
 
     public Dvh() {
         // Initial -> need to be calculated later
@@ -165,6 +166,14 @@ public class Dvh {
 
     public void setDvhSource(DataSource dvhSource) {
         this.dvhSource = dvhSource;
+    }
+
+    public Plan getPlan() {
+        return this.plan;
+    }
+
+    public void setPlan(Plan plan) {
+        this.plan = plan;
     }
 
     public XYChart appendChart(Structure structure, XYChart dvhChart) {

--- a/weasis-dicom/weasis-dicom-rt/src/main/java/org/weasis/dicom/rt/Structure.java
+++ b/weasis-dicom/weasis-dicom-rt/src/main/java/org/weasis/dicom/rt/Structure.java
@@ -34,6 +34,7 @@ public class Structure {
     private DataSource volumeSource;
 
     private Color color;
+    private Dvh dvh;
     private Map<KeyDouble, List<Contour>> planes;
 
     public Structure() {
@@ -113,6 +114,14 @@ public class Structure {
 
     public void setColor(Color color) {
         this.color = color;
+    }
+
+    public Dvh getDvh() {
+        return this.dvh;
+    }
+
+    public void setDvh(Dvh dvh) {
+        this.dvh = dvh;
     }
 
     public Map<KeyDouble, List<Contour>> getPlanes() {
@@ -207,11 +216,7 @@ public class Structure {
         if (StringUtil.hasText(this.rtRoiInterpretedType)) {
             resultLabel += " [" + this.rtRoiInterpretedType + "]";
         }
-
-        if (StringUtil.hasText(this.roiObservationLabel)) {
-            resultLabel += " (" + this.roiObservationLabel + ")";
-        }
-
+        
         return resultLabel;
     }
 


### PR DESCRIPTION
Now the lookup for iso contours is done according SOP Instance UID of Image slice (as we do for structure set contours). I also provided the code for filling up structure and isodose tooltips. Finally checkbox is added to UI to allow the strategy for generation of DVH (recalculate for all structures or only for structures that do not have DVH provided within the dose).