### PR TITLE
Re-creates missing download folder if needed.

### DIFF
--- a/weasis-dicom/weasis-dicom-explorer/src/main/java/org/weasis/dicom/explorer/wado/LoadSeries.java
+++ b/weasis-dicom/weasis-dicom-explorer/src/main/java/org/weasis/dicom/explorer/wado/LoadSeries.java
@@ -654,6 +654,15 @@ public class LoadSeries extends ExplorerTask<Boolean, String> implements SeriesI
             return Boolean.TRUE;
         }
 
+        // Solves missing tmp folder problem (on Windows).
+        private File getDicomTmpDir() {
+            if (!DICOM_TMP_DIR.exists()) {
+                LOGGER.info("DICOM tmp dir not foud. Re-creating it!");
+                AppProperties.buildAccessibleTempDirectory("downloading");
+            }
+            return DICOM_TMP_DIR;
+        }
+
         /**
          * Download file.
          *
@@ -670,7 +679,7 @@ public class LoadSeries extends ExplorerTask<Boolean, String> implements SeriesI
                 cache = false;
             }
             if (cache) {
-                tempFile = File.createTempFile("image_", ".dcm", DICOM_TMP_DIR); //$NON-NLS-1$ //$NON-NLS-2$
+                tempFile = File.createTempFile("image_", ".dcm", getDicomTmpDir()); //$NON-NLS-1$ //$NON-NLS-2$
             }
 
             // Cannot resume with WADO because the stream is modified on the fly by the wado server. In dcm4chee, see


### PR DESCRIPTION
Sometimes (on Windows) that "downloading" folder is deleted "at run-time", by something other than Weasis.

I believe that this "something" is some "cleaning" software or Windows feature to erase temp files. The folder always get deleted sometime after being used - when it is empty - and new downloads cannot be done anymore.

This solution simply recreates the file if it is not there when it is needed.