### PR TITLE
Add PreferenceDialog object as a property as a shortcut

### DIFF
--- a/weasis-core/src/main/java/org/weasis/core/ui/pref/PreferenceDialog.java
+++ b/weasis-core/src/main/java/org/weasis/core/ui/pref/PreferenceDialog.java
@@ -77,6 +77,8 @@ public class PreferenceDialog extends AbstractWizardDialog {
   protected void initializePages() {
     Hashtable<String, Object> properties = new Hashtable<>();
     properties.put("weasis.user.prefs", System.getProperty("weasis.user.prefs", "user")); // NON-NLS
+    properties.put("weasis.preferences.dialog", this); // pass this object as a property avoiding the need of changing
+                                                       // createInstance signature.
 
     ArrayList<AbstractItemDialogPage> list = new ArrayList<>();
     GeneralSetting generalSetting = new GeneralSetting(this);


### PR DESCRIPTION
This would allow new preferences tabs, other than the default ones, to have access to the main PreferenceDialog page.