### PR TITLE
Handle .zip files on drag-and-drop

### DIFF
--- a/weasis-base/weasis-base-ui/src/main/java/org/weasis/base/ui/gui/WeasisWin.java
+++ b/weasis-base/weasis-base-ui/src/main/java/org/weasis/base/ui/gui/WeasisWin.java
@@ -121,6 +121,7 @@ import org.weasis.core.api.gui.util.AbstractTabLicense;
 import org.weasis.core.api.gui.util.AppProperties;
 import org.weasis.core.api.gui.util.DynamicMenu;
 import org.weasis.core.api.gui.util.GuiExecutor;
+import org.weasis.core.api.gui.util.FileFormatFilter;
 import org.weasis.core.api.gui.util.GuiUtils;
 import org.weasis.core.api.gui.util.WinUtil;
 import org.weasis.core.api.media.data.Codec;
@@ -1199,10 +1200,12 @@ public class WeasisWin {
       }
       List<DataExplorerView> explorers = getImportableExplorers();
       List<Path> dirs = new ArrayList<>();
+      List<Path> zips = new ArrayList<>();
       Map<Codec, List<Path>> codecFiles = new HashMap<>();
 
-      categorizeFiles(files, dirs, codecFiles);
+      categorizeFiles(files, dirs, zips, codecFiles);
       processDirectories(explorers, dirs);
+      processZipFiles(explorers, zips);
       processCodecFiles(explorers, codecFiles);
       return true;
     }
@@ -1214,10 +1217,15 @@ public class WeasisWin {
     }
 
     private void categorizeFiles(
-        List<Path> files, List<Path> dirs, Map<Codec, List<Path>> codecFiles) {
+        List<Path> files,
+        List<Path> dirs,
+        List<Path> zips,
+        Map<Codec, List<Path>> codecFiles) {
       for (Path file : files) {
         if (Files.isDirectory(file)) {
           dirs.add(file);
+        } else if (FileFormatFilter.isZipFile(file)) {
+          zips.add(file);
         } else {
           categorizeMediaFile(file, codecFiles);
         }
@@ -1237,6 +1245,12 @@ public class WeasisWin {
     private void processDirectories(List<DataExplorerView> explorers, List<Path> dirs) {
       if (!dirs.isEmpty() && !explorers.isEmpty()) {
         importInExplorer(explorers, dirs, null);
+      }
+    }
+
+    private void processZipFiles(List<DataExplorerView> explorers, List<Path> zips) {
+      if (!zips.isEmpty() && !explorers.isEmpty()) {
+        importInExplorer(explorers, zips, null);
       }
     }
 

--- a/weasis-core/src/main/java/org/weasis/core/api/gui/util/FileFormatFilter.java
+++ b/weasis-core/src/main/java/org/weasis/core/api/gui/util/FileFormatFilter.java
@@ -10,7 +10,9 @@
 package org.weasis.core.api.gui.util;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Locale;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -92,6 +94,35 @@ public class FileFormatFilter extends FileFilter {
       }
     }
     return null;
+  }
+
+  /**
+   * Returns whether the path refers to a ZIP archive (by file extension).
+   *
+   * @param path the path to check (file or path)
+   * @return true if the path has a ".zip" extension (case-insensitive)
+   */
+  public static boolean isZipFile(Path path) {
+    if (path == null) {
+      return false;
+    }
+    Path name = path.getFileName();
+    return name != null
+        && name.toString().toLowerCase(Locale.ROOT).endsWith(".zip"); // NON-NLS
+  }
+
+  /**
+   * Returns whether the file refers to a ZIP archive (by file extension).
+   *
+   * @param file the file to check
+   * @return true if the file has a ".zip" extension (case-insensitive)
+   */
+  public static boolean isZipFile(File file) {
+    if (file == null || !file.isFile()) {
+      return false;
+    }
+    String name = file.getName();
+    return name != null && name.toLowerCase(Locale.ROOT).endsWith(".zip"); // NON-NLS
   }
 
   public void addExtension(String extension) {

--- a/weasis-core/src/test/java/org/weasis/core/api/gui/util/FileFormatFilterTest.java
+++ b/weasis-core/src/test/java/org/weasis/core/api/gui/util/FileFormatFilterTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2025 Weasis Team and other contributors.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse
+ * Public License 2.0 which is available at https://www.eclipse.org/legal/epl-2.0, or the Apache
+ * License, Version 2.0 which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package org.weasis.core.api.gui.util;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class FileFormatFilterTest {
+
+  @Nested
+  class IsZipFileForPath {
+
+    @Test
+    void returnsFalseForNull() {
+      assertFalse(FileFormatFilter.isZipFile((Path) null));
+    }
+
+    @Test
+    void returnsTrueForPathEndingWithZip() {
+      assertTrue(FileFormatFilter.isZipFile(Path.of("archive.zip")));
+      assertTrue(FileFormatFilter.isZipFile(Path.of("a", "b", "data.zip")));
+    }
+
+    @Test
+    void returnsTrueForPathEndingWithZipCaseInsensitive() {
+      assertTrue(FileFormatFilter.isZipFile(Path.of("archive.ZIP")));
+      assertTrue(FileFormatFilter.isZipFile(Path.of("archive.Zip")));
+    }
+
+    @Test
+    void returnsFalseForPathWithoutZipExtension() {
+      assertFalse(FileFormatFilter.isZipFile(Path.of("archive.dcm")));
+      assertFalse(FileFormatFilter.isZipFile(Path.of("readme")));
+      assertFalse(FileFormatFilter.isZipFile(Path.of("file.zipx")));
+    }
+
+    @Test
+    void returnsTrueWhenFilenameIsOnlyZip() {
+      assertTrue(FileFormatFilter.isZipFile(Path.of(".zip")));
+    }
+  }
+
+  @Nested
+  class IsZipFileForFile {
+
+    @Test
+    void returnsFalseForNull() {
+      assertFalse(FileFormatFilter.isZipFile((File) null));
+    }
+
+    @Test
+    void returnsFalseForDirectory(@TempDir Path tempDir) {
+      assertFalse(FileFormatFilter.isZipFile(tempDir.toFile()));
+    }
+
+    @Test
+    void returnsTrueForExistingFileWithZipExtension(@TempDir Path tempDir) throws IOException {
+      Path zipPath = Files.createFile(tempDir.resolve("archive.zip"));
+      assertTrue(FileFormatFilter.isZipFile(zipPath.toFile()));
+    }
+
+    @Test
+    void returnsTrueForExistingFileWithZipExtensionCaseInsensitive(@TempDir Path tempDir)
+        throws IOException {
+      Path zipPath = Files.createFile(tempDir.resolve("archive.ZIP"));
+      assertTrue(FileFormatFilter.isZipFile(zipPath.toFile()));
+    }
+
+    @Test
+    void returnsFalseForExistingFileWithoutZipExtension(@TempDir Path tempDir)
+        throws IOException {
+      Path filePath = Files.createFile(tempDir.resolve("data.dcm"));
+      assertFalse(FileFormatFilter.isZipFile(filePath.toFile()));
+    }
+  }
+}

--- a/weasis-dicom/weasis-dicom-explorer/src/main/java/org/weasis/dicom/explorer/DicomSeriesHandler.java
+++ b/weasis-dicom/weasis-dicom-explorer/src/main/java/org/weasis/dicom/explorer/DicomSeriesHandler.java
@@ -12,6 +12,7 @@ package org.weasis.dicom.explorer;
 import java.awt.datatransfer.Transferable;
 import java.io.File;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -21,6 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.weasis.core.api.explorer.model.DataExplorerModel;
 import org.weasis.core.api.explorer.model.TreeModel;
+import org.weasis.core.api.gui.util.FileFormatFilter;
 import org.weasis.core.api.gui.util.GuiUtils;
 import org.weasis.core.api.media.data.Series;
 import org.weasis.core.api.media.data.TagW;
@@ -32,6 +34,7 @@ import org.weasis.core.ui.editor.image.ViewCanvas;
 import org.weasis.dicom.codec.DicomImageElement;
 import org.weasis.dicom.codec.DicomSeries;
 import org.weasis.dicom.explorer.HangingProtocols.OpeningViewer;
+import org.weasis.dicom.explorer.imp.DicomZipImport;
 import org.weasis.dicom.explorer.imp.LocalImport;
 import org.weasis.dicom.explorer.main.DicomExplorer;
 import org.weasis.dicom.explorer.main.SeriesSelectionModel;
@@ -88,9 +91,10 @@ public class DicomSeriesHandler extends SequenceHandler {
   }
 
   /**
-   * Handles dropping DICOM files for import.
+   * Handles dropping DICOM files and ZIP archives for import. ZIP files are processed the same way
+   * as when using the Import dialog (extracted then loaded like a folder).
    *
-   * @param paths the list of file paths to import
+   * @param paths the list of file paths to import (files, directories, or .zip archives)
    * @return true if import was initiated successfully
    */
   public static boolean dropDicomFiles(List<Path> paths) {
@@ -103,9 +107,25 @@ public class DicomSeriesHandler extends SequenceHandler {
               var model = explorer.getDataExplorerModel();
               var openingViewer =
                   OpeningViewer.getOpeningViewerByLocalKey(LocalImport.LAST_OPEN_VIEWER_MODE);
-              var files = paths.stream().map(Path::toFile).toArray(File[]::new);
-              DicomModel.LOADING_EXECUTOR.execute(
-                  new LoadLocalDicom(files, true, model, openingViewer));
+              var parent = GuiUtils.getUICore().getApplicationWindow();
+
+              List<Path> nonZipPaths = new ArrayList<>();
+              for (Path p : paths) {
+                if (FileFormatFilter.isZipFile(p)) {
+                  File zipFile = p.toFile();
+                  if (zipFile.canRead()) {
+                    DicomZipImport.loadDicomZip(zipFile, model, openingViewer, parent);
+                  }
+                } else {
+                  nonZipPaths.add(p);
+                }
+              }
+              if (!nonZipPaths.isEmpty()) {
+                var files = nonZipPaths.stream().map(Path::toFile).toArray(File[]::new);
+                DicomModel.LOADING_EXECUTOR.execute(
+                    new LoadLocalDicom(files, true, model, openingViewer));
+              }
+
               return true;
             })
         .orElse(false);

--- a/weasis-dicom/weasis-dicom-explorer/src/main/java/org/weasis/dicom/explorer/main/DicomExplorer.java
+++ b/weasis-dicom/weasis-dicom-explorer/src/main/java/org/weasis/dicom/explorer/main/DicomExplorer.java
@@ -29,6 +29,7 @@ import org.weasis.core.api.explorer.DataExplorerView;
 import org.weasis.core.api.explorer.ObservableEvent;
 import org.weasis.core.api.gui.Insertable;
 import org.weasis.core.api.gui.util.ActionW;
+import org.weasis.core.api.gui.util.FileFormatFilter;
 import org.weasis.core.api.gui.util.GuiExecutor;
 import org.weasis.core.api.gui.util.GuiUtils;
 import org.weasis.core.api.media.data.*;
@@ -48,6 +49,7 @@ import org.weasis.dicom.explorer.*;
 import org.weasis.dicom.explorer.Messages;
 import org.weasis.dicom.explorer.exp.ExplorerTask;
 import org.weasis.dicom.explorer.exp.ExportToolBar;
+import org.weasis.dicom.explorer.imp.DicomZipImport;
 import org.weasis.dicom.explorer.imp.ImportToolBar;
 import org.weasis.dicom.explorer.imp.LocalImport;
 
@@ -943,12 +945,27 @@ public class DicomExplorer extends PluginTool
 
   @Override
   public void importFiles(File[] files, boolean recursive) {
-    if (files != null) {
-      HangingProtocols.OpeningViewer openingViewer =
-          HangingProtocols.OpeningViewer.getOpeningViewerByLocalKey(
-              LocalImport.LAST_OPEN_VIEWER_MODE);
+    if (files == null || files.length == 0) {
+      return;
+    }
+    HangingProtocols.OpeningViewer openingViewer =
+        HangingProtocols.OpeningViewer.getOpeningViewerByLocalKey(
+            LocalImport.LAST_OPEN_VIEWER_MODE);
+    Component parent = GuiUtils.getUICore().getApplicationWindow();
+    List<File> nonZipFiles = new ArrayList<>();
+    for (File f : files) {
+      if (FileFormatFilter.isZipFile(f)) {
+        if (f.canRead()) {
+          DicomZipImport.loadDicomZip(f, model, openingViewer, parent);
+        }
+      } else {
+        nonZipFiles.add(f);
+      }
+    }
+    if (!nonZipFiles.isEmpty()) {
+      File[] rest = nonZipFiles.toArray(new File[0]);
       DicomModel.LOADING_EXECUTOR.execute(
-          new LoadLocalDicom(files, recursive, model, openingViewer));
+          new LoadLocalDicom(rest, recursive, model, openingViewer));
     }
   }
 


### PR DESCRIPTION
Call `DicomZipImport.loadDicomZip` for .zip files drag&dropped by the user.

Code is a bit duplicated, because the explorer and the center pane have seperate drag&drop handler. But i tried to keep it as clean as possible.