### PR TITLE
Fix scroll synchronization cross-container & manual sync disabled when creating a new container #840

### DIFF
--- a/weasis-dicom/weasis-dicom-viewer2d/src/main/java/org/weasis/dicom/viewer2d/DicomSynchManager.java
+++ b/weasis-dicom/weasis-dicom-viewer2d/src/main/java/org/weasis/dicom/viewer2d/DicomSynchManager.java
@@ -264,6 +264,15 @@ public class DicomSynchManager extends SynchManager<DicomImageElement> {
     }
 
     boolean manualSyncActivated = synch.isManualSynchActivated();
+    // Add check if any of the views has manualSync activated
+    long manuallySyncedViews = views.stream().filter(v -> {
+      ViewSynchData sd = (ViewSynchData) v.getActionValue(ActionW.SYNCH_LINK.cmd());
+      return (sd != null && sd.isManualSynchActivated());
+    }).count();
+    if (manuallySyncedViews > 0) {
+        manualSyncActivated = true;
+        synch.setManualSyncState(SyncState.ON);
+    }
     StackSyncContext ctx =
         new StackSyncContext(series, synch, slicePosition, frUidsMap, synchActivated);
 
@@ -533,22 +542,27 @@ public class DicomSynchManager extends SynchManager<DicomImageElement> {
     List<ViewCanvas<DicomImageElement>> views = getSiblingViews(viewerPlugin, viewPane);
     if (!views.isEmpty() || viewPane != null) {
       if (viewerPlugin instanceof View2dContainer) {
-        addVisibleViews(views, viewerPlugin);
+        List<ViewCanvas<DicomImageElement>> viewsFromOtherContainers = addVisibleViews(viewerPlugin);
+        for (ViewCanvas<DicomImageElement> vc : viewsFromOtherContainers) {
+          if (vc != null && vc.getSeries() != null && hasSameFrUid(vc.getSeries(), viewPane.getSeries())) {
+            views.add(vc);
+          }
+        }
       }
     }
     return views;
   }
 
-  private void addVisibleViews(
-      List<ViewCanvas<DicomImageElement>> views,
-      ImageViewerPlugin<DicomImageElement> viewerPlugin) {
+  private List<ViewCanvas<DicomImageElement>> addVisibleViews(ImageViewerPlugin<DicomImageElement> viewerPlugin) {
     List<ViewerPlugin<?>> viewerPlugins = GuiUtils.getUICore().getViewerPlugins();
+    List<ViewCanvas<DicomImageElement>> viewsFromOtherContainers = new java.util.ArrayList<>();
     synchronized (viewerPlugins) {
       viewerPlugins.stream()
-          .filter(plugin -> shouldIncludePlugin(plugin, viewerPlugin))
-          .map(plugin -> (View2dContainer) plugin)
-          .forEach(container -> views.addAll(container.getImagePanels()));
+              .filter(plugin -> shouldIncludePlugin(plugin, viewerPlugin))
+              .map(plugin -> (View2dContainer) plugin)
+              .forEach(container -> viewsFromOtherContainers.addAll(container.getImagePanels()));
     }
+    return viewsFromOtherContainers;
   }
 
   private boolean shouldIncludePlugin(

--- a/weasis-dicom/weasis-dicom-viewer2d/src/main/java/org/weasis/dicom/viewer2d/EventManager.java
+++ b/weasis-dicom/weasis-dicom-viewer2d/src/main/java/org/weasis/dicom/viewer2d/EventManager.java
@@ -321,9 +321,6 @@ public class EventManager extends ImageViewerEventManager<DicomImageElement>
 
         if (image != null
             && layoutAction.isPresent()
-            && View2dFactory.getViewTypeNumber(
-                    (MigLayoutModel) layoutAction.get().getSelectedItem(), ViewCanvas.class)
-                > 1
             && synchAction.isPresent()) {
 
           SynchView synchview = (SynchView) synchAction.get().getSelectedItem();


### PR DESCRIPTION
Removed a condition when sending a sync event that removed the location information in the event to activate scroll auto synchronization in several containers, cross lines when different orientation or position synchronization is same orientation.
If a manual sync is activated in a container between multiple views, and a new container is created (right click on a series and open in a new tab), the manual synchro configuration was lost. Now we check for any configuration present in a view and apply it to the container when the focus changes between containers.