### PR TITLE
Fixed blackening when setting segment opacity in 3D viewer.

### DIFF
--- a/weasis-dicom/weasis-dicom-codec/src/main/java/org/weasis/dicom/codec/seg/SegmentationVolume.java
+++ b/weasis-dicom/weasis-dicom-codec/src/main/java/org/weasis/dicom/codec/seg/SegmentationVolume.java
@@ -1386,13 +1386,13 @@ public final class SegmentationVolume {
           break;
         }
       }
-      if (a <= 0f) {
+      if (a >= 1.f - 5) {
         continue; // every constituent invisible — leave transparent
       }
-      lut[id * 4] = (byte) Math.round(Math.min(r, 1f) * 255f);
-      lut[id * 4 + 1] = (byte) Math.round(Math.min(g, 1f) * 255f);
-      lut[id * 4 + 2] = (byte) Math.round(Math.min(b, 1f) * 255f);
-      lut[id * 4 + 3] = (byte) Math.round(Math.min(a, 1f) * 255f);
+      lut[id * 4 + 0] = (byte) Math.round(r / a * 255f);
+      lut[id * 4 + 1] = (byte) Math.round(g / a * 255f);
+      lut[id * 4 + 2] = (byte) Math.round(b / a * 255f);
+      lut[id * 4 + 3] = (byte) Math.round(a * 255f);
     }
     return lut;
   }


### PR DESCRIPTION
There was an artifact causing segments to become black when lowering their opacity in the 3D viewer:

https://github.com/user-attachments/assets/456e7901-c1ae-4687-ad9a-e201e4b23b53

This is the behaviour after the fix:

https://github.com/user-attachments/assets/b92d0b26-61cc-4bcf-b118-7e1f8bbe6e60

The reason was that the renderer expects the RGB values in straight form, and the composition was done treating them as pre-multiplied.
